### PR TITLE
Fix ml-kem link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -3,7 +3,7 @@
 We maintain dozens of popular crates which provide pure Rust implementations of cryptographic algorithms,
 including the following:
 
-- **Asymmetric encryption**: [`elliptic-curves`](https://github.com/RustCrypto/elliptic-curves), [`ml-kem`](https://github.com/RustCrypto/formats/tree/master/ml-kem), [`rsa`](https://github.com/RustCrypto/RSA)
+- **Asymmetric encryption**: [`elliptic-curves`](https://github.com/RustCrypto/elliptic-curves), [`ml-kem`](https://github.com/RustCrypto/KEMs/tree/master/ml-kem), [`rsa`](https://github.com/RustCrypto/RSA)
 - **Cryptographic encoding formats**: [`const-oid`](https://github.com/RustCrypto/formats/tree/master/const-oid), [`der`](https://github.com/RustCrypto/formats/tree/master/der), [`pem-rfc7468`](https://github.com/RustCrypto/formats/tree/master/pem-rfc7468), [`pkcs8`](https://github.com/RustCrypto/formats/tree/master/pkcs8)
 - **Digital signatures**: [`dsa`](https://github.com/RustCrypto/signatures/tree/master/dsa), [`ecdsa`](https://github.com/RustCrypto/signatures/tree/master/ecdsa), [`ed25519`](https://github.com/RustCrypto/signatures/tree/master/ed25519), [`rsa`](https://github.com/RustCrypto/RSA)
 - **Elliptic curves**: [`k256`](https://github.com/RustCrypto/elliptic-curves/tree/master/k256) (secp256k1), [`p256`](https://github.com/RustCrypto/elliptic-curves/tree/master/p256), [`p384`](https://github.com/RustCrypto/elliptic-curves/tree/master/p384) 


### PR DESCRIPTION
This pull request includes a minor update to the `profile/README.md` file. The change corrects the URL for the `ml-kem` repository under the "Asymmetric encryption" section.
